### PR TITLE
Add IE11 support

### DIFF
--- a/src/app/demo-tinymce/demo-tinymce.component.ts
+++ b/src/app/demo-tinymce/demo-tinymce.component.ts
@@ -49,7 +49,14 @@ export class DemoTinymceComponent {
       let frame = <any>window.frames[ed.iframeElement.id];
       let contentEditable = frame.contentDocument.getElementById('tinymce');
       comp._zone.run(() => {
-        comp.mention.keyHandler(e, contentEditable);
+        comp.mention.keyDownHandler(e, contentEditable);
+      });
+    });
+    ed.on('keypress', function(e) {
+      let frame = <any>window.frames[ed.iframeElement.id];
+      let contentEditable = frame.contentDocument.getElementById('tinymce');
+      comp._zone.run(() => {
+        comp.mention.keyPressHandler(e, contentEditable);
       });
     });
     ed.on('init', function(args) {


### PR DESCRIPTION
Rewrote keyhandling due to lack of ie11 compatibility. 

IE11 does not support special characters (i.e. @) in keydown event [http://unixpapa.com/js/key.html]. Had to split existing keyhandling into keypresshandling for showing up the search list and keydownhandling for navigating within the search list. 