### PR TITLE
Format mention text with selected element when it's a object

### DIFF
--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -63,7 +63,7 @@ export class MentionDirective implements OnInit, OnChanges {
   private maxItems:number = -1;
 
   // optional function to format the selected item before inserting the text
-  private mentionSelect: (item: any) => (string) = (item: any) => this.triggerChar + item[this.labelKey];
+  private mentionSelect: (item: any) => (any) = (item: any);
 
   searchString: string;
   startPos: number;

--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -63,7 +63,7 @@ export class MentionDirective implements OnInit, OnChanges {
   private maxItems:number = -1;
 
   // optional function to format the selected item before inserting the text
-  private mentionSelect: (item: any) => (any) = (item: any);
+  private mentionSelect: (item: any) => (any) = (item: any) => item;
 
   searchString: string;
   startPos: number;


### PR DESCRIPTION
Most cases we tend to have objects in mentions list than simple strings. It is much better if we can give the flexibility to modify the text with object contents such as Id. 
It is much useful when integrated with editors such as tinymce where we could create custom html tags with data-* attributed for business logic. 