### PR TITLE
Support for HTML formatting when using mentions with contenteditable

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,7 +11,7 @@ and content editable fields. Try entering some @names below.</p>
 <textarea [mention]="items" class="form-control" cols="60" rows="4"></textarea>
 
 <h3>Content Editable</h3>
-<div [mention]="items" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
+<app-demo-contenteditable [items]="items"></app-demo-contenteditable>
 
 <h3>Embedded Editor</h3>
 <app-demo-tinymce></app-demo-tinymce>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,7 @@ import { DemoAsyncComponent } from './demo-async/demo-async.component';
 import { DemoOptionsComponent } from './demo-options/demo-options.component';
 import { DemoTemplateComponent } from './demo-template/demo-template.component';
 import { DemoTinymceComponent } from './demo-tinymce/demo-tinymce.component';
+import { DemoContenteditableComponent } from './demo-contenteditable/demo-contenteditable.component';
 
 @NgModule({
   imports: [
@@ -25,7 +26,8 @@ import { DemoTinymceComponent } from './demo-tinymce/demo-tinymce.component';
     DemoAsyncComponent,
     DemoOptionsComponent,
     DemoTemplateComponent,
-    DemoTinymceComponent
+    DemoTinymceComponent,
+    DemoContenteditableComponent
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/demo-contenteditable/demo-contenteditable.component.html
+++ b/src/app/demo-contenteditable/demo-contenteditable.component.html
@@ -1,0 +1,6 @@
+<div #input
+     [mention]="items"
+     [mentionConfig]="{mentionSelect: formatItem}"
+     class="form-control"
+     contenteditable="true"
+     style="border:1px lightgrey solid;min-height:88px"></div>

--- a/src/app/demo-contenteditable/demo-contenteditable.component.ts
+++ b/src/app/demo-contenteditable/demo-contenteditable.component.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, Input, ViewChild} from '@angular/core';
+import {Component, Input} from '@angular/core';
 
 @Component({
   selector: 'app-demo-contenteditable',
@@ -6,16 +6,8 @@ import {Component, ElementRef, Input, ViewChild} from '@angular/core';
 })
 export class DemoContenteditableComponent {
   @Input() items: any[];
-  @ViewChild('input') el: ElementRef;
 
-  constructor() { }
-
-  formatItem = (item) => {
-      // setTimeout(() => {
-      //     const text = this.el.nativeElement.textContent;
-      //     this.el.nativeElement.innerHTML = text;
-      // }, 100);
-
+  formatItem(item) {
     return `<em>${item.label}</em>`;
   }
 }

--- a/src/app/demo-contenteditable/demo-contenteditable.component.ts
+++ b/src/app/demo-contenteditable/demo-contenteditable.component.ts
@@ -1,0 +1,21 @@
+import {Component, ElementRef, Input, ViewChild} from '@angular/core';
+
+@Component({
+  selector: 'app-demo-contenteditable',
+  templateUrl: './demo-contenteditable.component.html'
+})
+export class DemoContenteditableComponent {
+  @Input() items: any[];
+  @ViewChild('input') el: ElementRef;
+
+  constructor() { }
+
+  formatItem = (item) => {
+      // setTimeout(() => {
+      //     const text = this.el.nativeElement.textContent;
+      //     this.el.nativeElement.innerHTML = text;
+      // }, 100);
+
+    return `<em>${item.label}</em>`;
+  }
+}


### PR DESCRIPTION
Selected item can now be formatted as HTML when `[mention]` is used on `contenteditable` element. See `demo-contenteditable` component for example.