### PR TITLE
Add ability to insert HTML Elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,63 @@ The following optional configuration items can be used.
 | ---           | ---      | ---         |
 | triggerChar   | @        | The character that will trigger the menu behavior. |
 | maxItems      |          | Limit the number of items shown in the pop-up menu. The default is no limit. |
-| mentionSelect |          | An optional function to format the selected item before inserting the text. |
+| insertHTML    | false    | Insert HTML instead of plain text. |
+| mentionSelect |          | An optional function to format the selected item before inserting the text.  Use this function to create HTML. |
 | labelKey      | label    | The field to be used as the item label (when the items are objects). |
 | disableSearch | false    | Disable internal filtering (only useful if async search is used). |
 
-For Example: 
+Options Example: 
 
     <input type="text" [mention]="items" [mentionConfig]="{triggerChar:'#',maxItems:10,labelKey:'name'}">
+
+HTML Element Example:
+
+    <div
+        [mention]="items"
+        [mentionConfig]="{
+            insertHTML: true,
+            mentionSelect: insertSpanElement
+        }"
+        class="form-control"
+        contenteditable="true"
+        style="border:1px lightgrey solid;min-height:88px"></div>
+
+    /**
+     * Note: There is no way to add a trailing space after this span.
+     * There will be useability consequences.
+     */
+    public insertSpanElement(name) {
+        let el = document.createElement("span");
+        el.contentEditable = "false";
+        el.className = "mention";
+        el.innerText = `@${name.label}`;
+        return el;
+    }
+
+HTML Code Example:
+
+    <div
+        [mention]="items"
+        [mentionConfig]="{
+            insertHTML: true,
+            mentionSelect: insertSpanText
+        }"
+        class="form-control"
+        contenteditable="true"
+        style="border:1px lightgrey solid;min-height:88px"></div>
+
+    /**
+     * Note the trailig &nbsp;.
+     * It helps with useability.
+     */
+    public insertSpanText(name) {
+        return `
+        <span
+            class="mention"
+            contenteditable="false"
+            >@${name.label}</span>&nbsp;
+        `;
+    }
 
 #### Output Events
 

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,6 @@
+/* Example CSS for an @mention */
+.mention {
+    background-color: #eee;
+    border-radius: 0.25em;
+    padding: 0.5em;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -10,8 +10,30 @@ and content editable fields. Try entering some @names below.</p>
 <h3>Textarea</h3>
 <textarea [mention]="items" class="form-control" cols="60" rows="4"></textarea>
 
-<h3>Content Editable</h3>
+<h3>Content Editable - Plain Text</h3>
 <div [mention]="items" class="form-control" contenteditable="true" style="border:1px lightgrey solid;min-height:88px"></div>
+
+<h3>Content Editable - HTML Element Insertion</h3>
+<div
+    [mention]="items"
+    [mentionConfig]="{
+        insertHTML: true,
+        mentionSelect: insertSpanElement
+    }"
+    class="form-control"
+    contenteditable="true"
+    style="border:1px lightgrey solid;min-height:88px"></div>
+
+<h3>Content Editable - HTML Code Insertion</h3>
+<div
+    [mention]="items"
+    [mentionConfig]="{
+        insertHTML: true,
+        mentionSelect: insertSpanText
+    }"
+    class="form-control"
+    contenteditable="true"
+    style="border:1px lightgrey solid;min-height:88px"></div>
 
 <h3>Embedded Editor</h3>
 <app-demo-tinymce></app-demo-tinymce>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,4 +12,29 @@ import { COMMON_NAMES } from './common-names';
 })
 export class AppComponent {
   items: string[] = COMMON_NAMES;
+
+  /**
+   * Note: There is no way to add a trailing space after this span.
+   * There will be useability consequences.
+   */
+  public insertSpanElement(name) {
+    let el = document.createElement("span");
+    el.contentEditable = "false";
+    el.className = "mention";
+    el.innerText = `@${name.label}`;
+    return el;
+  }
+
+  /**
+   * Note the trailig &nbsp;.
+   * It helps with useability.
+   */
+  public insertSpanText(name) {
+    return `
+    <span
+      class="mention"
+      contenteditable="false"
+      >@${name.label}</span>&nbsp;
+    `;
+  }
 }

--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -41,6 +41,7 @@ export class MentionDirective implements OnInit, OnChanges {
     this.labelKey = config.labelKey || this.labelKey;
     this.disableSearch = config.disableSearch || this.disableSearch;
     this.maxItems = config.maxItems || this.maxItems;
+    this.insertHTML = config.insertHTML || this.insertHTML;
     this.mentionSelect = config.mentionSelect || this.mentionSelect;
   }
 
@@ -62,6 +63,9 @@ export class MentionDirective implements OnInit, OnChanges {
 
   // option to limit the number of items shown in the pop-up menu
   private maxItems:number = -1;
+
+  //Insert Text (false) or HTML (true)
+  private insertHTML:boolean = false;
 
   // optional function to format the selected item before inserting the text
   private mentionSelect: (item: any) => (string) = (item: any) => this.triggerChar + item[this.labelKey];
@@ -188,6 +192,7 @@ export class MentionDirective implements OnInit, OnChanges {
             // value is inserted without a trailing space for consistency
             // between element types (div and iframe do not preserve the space)
             insertValue(nativeElement, this.startPos, pos,
+              this.insertHTML,
               this.mentionSelect(this.searchList.activeItem), this.iframe);
             // fire input event so angular bindings are updated
             if ("createEvent" in document) {


### PR DESCRIPTION
HTML Elements can be inserted using a mentionSelect function that either returns an HTMLElement object or HTML code as a string.  See README changes for an example of both options.