### PR TITLE
Return items with 'includes' searchTerm instead of 'startsWith'

### DIFF
--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -268,7 +268,7 @@ export class MentionDirective implements OnChanges {
       // disabling the search relies on the async operation to do the filtering
       if (!this.disableSearch && this.searchString) {
         let searchStringLowerCase = this.searchString.toLowerCase();
-        objects = objects.filter(e => e[this.activeConfig.labelKey].toLowerCase().startsWith(searchStringLowerCase));
+        objects = objects.filter(e => e[this.activeConfig.labelKey].toLowerCase().includes(searchStringLowerCase));
       }
       matches = objects;
       if (this.activeConfig.maxItems > 0) {


### PR DESCRIPTION
Modified UpdateSearchList function to return items with 'includes' searchTerm instead of startsWith. 
@dmacfarlane , please take a look when you got some time. 

Thanks!