### PR TITLE
Remove bootstrap dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ Add the package as a dependency to your project using:
 
     npm install angular-mentions
 
-Add the CSS to your index.html:
-
-```html
-<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
-```
 
 Add the module to your app.module imports:
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "protractor": "^5.4.2",
     "ts-node": "~7.0.0",
     "tsickle": ">=0.34.0",
-    "tslib": "^1.9.0",
     "tslint": "~5.11.0",
     "typescript": "~3.2.2"
   }

--- a/projects/angular-mentions/README.md
+++ b/projects/angular-mentions/README.md
@@ -20,11 +20,6 @@ Add the package as a dependency to your project using:
 
     npm install angular-mentions
 
-Add the CSS to your index.html:
-
-```html
-<link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
-```
 
 Add the module to your app.module imports:
 

--- a/projects/angular-mentions/src/lib/mention-list.component.css
+++ b/projects/angular-mentions/src/lib/mention-list.component.css
@@ -1,0 +1,43 @@
+.dropdown-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1000;
+    display: none;
+    float: left;
+    min-width: 10rem;
+    padding: 0.5rem 0;
+    margin: 0.125rem 0 0;
+    font-size: 1rem;
+    color: #212529;
+    text-align: left;
+    list-style: none;
+    background-color: #fff;
+    background-clip: padding-box;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 0.25rem;
+  }
+  .dropdown-item {
+    display: block;
+    padding: 0.25rem 1.5rem;
+    clear: both;
+    font-weight: 400;
+    color: #212529;
+    text-align: inherit;
+    white-space: nowrap;
+    background-color: transparent;
+    border: 0;
+  }
+  .scrollable-menu {
+    display: block;
+    height: auto;
+    max-height: 300px;
+    overflow: auto;
+  }
+  [hidden] {
+    display: none;
+  }
+  li.active {
+    background-color: #f7f7f9;
+  }
+  

--- a/projects/angular-mentions/src/lib/mention-list.component.ts
+++ b/projects/angular-mentions/src/lib/mention-list.component.ts
@@ -13,22 +13,7 @@ import { getCaretCoordinates } from './caret-coords';
  */
 @Component({
   selector: 'mention-list',
-  styles: [`
-      .scrollable-menu {
-        display: block;
-        height: auto;
-        max-height: 300px;
-        overflow: auto;
-      }
-    `,`
-      [hidden] {
-        display: none;
-      }
-    `,`
-      li.active {
-        background-color: #f7f7f9;
-      }
-    `],
+  styleUrls: ['./mention-list.component.css'],
   template: `
     <ng-template #defaultItemTemplate let-item="item">
       {{item[labelKey]}}

--- a/projects/demo-app/src/index.html
+++ b/projects/demo-app/src/index.html
@@ -7,7 +7,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <!-- Dependancies -->
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
   <script src="//cdn.tinymce.com/4/tinymce.min.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Removing bootstrap will make library smaller and not dependant on third party library. Not everyone uses bootstrap and adding whole bootstrap only to use mentions is probably not the best idea