### PR TITLE
Update mention.directive.ts

### DIFF
--- a/projects/angular-mentions/src/lib/mention.directive.ts
+++ b/projects/angular-mentions/src/lib/mention.directive.ts
@@ -350,6 +350,12 @@ export class MentionDirective implements OnChanges {
       this.searchList.items = matches;
       this.searchList.hidden = matches.length == 0;
     }
+    
+    // fixes close event not triggering when the search term doesn't match but the ui closes
+    if (matches.length == 0) {
+      this.searchList.hidden = false; // Forcing the search list hidden attribute as this isn't fiered when the ui closes
+      this.stopSearch();
+    }
   }
 
   showSearchList(nativeElement: HTMLInputElement) {


### PR DESCRIPTION
This change fixes the `close` event not triggering when the ui closes when the search term doesn't match